### PR TITLE
feat(cloud): accept cloud-ready options

### DIFF
--- a/sdk/botpress.d.ts
+++ b/sdk/botpress.d.ts
@@ -898,7 +898,6 @@ declare module 'botpress/sdk' {
 
     cloud?: CloudConfig
     isCloudBot?: boolean
-    bpCloudApiKey?: string
   }
 
   export interface CloudConfig {

--- a/sdk/botpress.d.ts
+++ b/sdk/botpress.d.ts
@@ -487,6 +487,7 @@ declare module 'botpress/sdk' {
 
     export interface EventUnderstanding {
       readonly errored: boolean
+      readonly modelId: string | undefined
 
       readonly predictions?: {
         [context: string]: {

--- a/sdk/botpress.d.ts
+++ b/sdk/botpress.d.ts
@@ -897,6 +897,8 @@ declare module 'botpress/sdk' {
     }
 
     cloud?: CloudConfig
+    isCloudBot?: boolean
+    bpCloudApiKey?: string
   }
 
   export interface CloudConfig {


### PR DESCRIPTION
https://linear.app/botpress/issue/DEV-2026/a-user-can-enter-cloud-ready-options-when-creating-a-bot-on-the-admin

Adds cloud-ready options to `BotConfig`

Currently they are added on the root `BotConfig` object. Waiting to hear if they need to be moved into the `cloud` property and under what keys.

### Related PRs
- https://github.com/botpress/studio/pull/212
- https://github.com/botpress/botpress/pull/5704
